### PR TITLE
Add per-question feedback formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ gunicorn main:flask_app
 ```
 
 The bot will listen for events from Slack as configured in your Slack App.
+
+## Feedback Format Options
+
+When creating a feedback poll, each question can now be configured individually
+to collect answers as free-form paragraphs or as a 1–5 ranking. Select the
+desired format for each question in the creation modal.


### PR DESCRIPTION
## Summary
- allow each feedback question to specify its own answer format
- store a list of formats in poll state
- update feedback modal and results displays to use per-question formats
- document the new option in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*