### PR TITLE
Extend poll questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Terms of Service.
 
 ## Feedback Format Options
 
-When creating a feedback poll, each question can now be configured individually
-to collect answers as free-form paragraphs or as a 1–5 ranking. Select the
-desired format for each question in the creation modal.
+When creating a feedback poll, you can now add up to *ten* questions. Each
+question may be set as a multiple-choice vote or a traditional feedback
+question. Feedback questions still allow either free-form paragraphs or a
+1–5 ranking.
 
 ## Multiple Selections
 


### PR DESCRIPTION
## Summary
- allow up to ten options or feedback questions when creating polls
- provide a selector for each feedback question to mark it as a vote or feedback question
- display yes/no vote controls for vote questions in feedback polls
- aggregate vote question tallies when showing or closing polls
- document the new behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6c1bdec0832fbb3f3c789aba01ef