### PR TITLE
Add blended poll type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ question may be set as a multiple-choice vote or a traditional feedback
 question. Feedback questions still allow either free-form paragraphs or a
 1–5 ranking.
 
+## Blended Polls
+
+The initial modal now lets you choose *Vote*, *Feedback* or *Blended*.
+Selecting **Blended** prompts you for up to ten questions where each question
+can be marked as either a vote or feedback prompt. Vote questions can include
+up to five custom options for participants to choose from.
+
 ## Multiple Selections
 
 When creating a vote poll, you can optionally allow participants to choose more

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -143,3 +143,27 @@ def test_handle_poll_step1_ack_update(main_module):
     assert payloads
     assert payloads[0]['response_action'] == 'update'
     assert payloads[0]['view']['callback_id'] == 'submit_poll'
+
+
+def test_handle_poll_step1_blended(main_module):
+    payloads = []
+    def ack(**kwargs):
+        payloads.append(kwargs)
+
+    body = {'trigger_id': 'T1'}
+    view = {
+        'private_metadata': json.dumps({'channel': 'C1', 'user': 'U1'}),
+        'state': {
+            'values': {
+                'type_block': {'poll_type': {'selected_option': {'value': 'blended'}}},
+                'question_block': {'question_input': {'value': 'Q'}},
+                'visibility_block': {'visibility_select': {'selected_option': {'value': 'public'}}},
+            }
+        }
+    }
+
+    main_module.handle_poll_step1(ack, body, view, client=object())
+
+    assert payloads
+    assert payloads[0]['response_action'] == 'update'
+    assert payloads[0]['view']['callback_id'] == 'submit_poll'


### PR DESCRIPTION
## Summary
- add 'Blended' poll type to modal
- allow each blended question to be marked vote or feedback with up to 5 options
- track per-question options and tallies
- document blended polls
- test blended question modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9688453c832f9c754947761f0a1f