### PR TITLE
Update canvas upload helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,13 +63,14 @@ def upload_results_canvas(client, channel_id, markdown, team_id=None, title=None
     Returns a permalink to the new Canvas, or None on failure.
     """
     try:
+        # Use “channel=…” instead of “channel_id=…” for the Canvas API call
         response = client.conversations_canvases_create(
-            channel_id=channel_id,
+            channel=channel_id,
             title=title or "Poll Results",
             document_content={
                 "type": "markdown",
-                "markdown": markdown,
-            },
+                "markdown": markdown
+            }
         )
         canvas_id = response.get("canvas", {}).get("id")
         if canvas_id and team_id:

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -86,8 +86,8 @@ class MockSlackClient:
     def chat_postMessage(self, channel=None, text=None):
         self.messages.append({'channel': channel, 'text': text})
 
-    def conversations_canvases_create(self, channel_id=None, document_content=None, title=None):
-        self.canvases.append({'channel_id': channel_id, 'document_content': document_content, 'title': title})
+    def conversations_canvases_create(self, channel=None, document_content=None, title=None):
+        self.canvases.append({'channel': channel, 'document_content': document_content, 'title': title})
         return {'canvas': {'id': '12345'}}
 
 


### PR DESCRIPTION
## Summary
- support new Slack Canvas API parameter names
- adjust tests to reflect updated helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c113d2f4832f865a9405eddc4d2e