### PR TITLE
Fix Canvas API parameter name

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,9 +63,8 @@ def upload_results_canvas(client, channel_id, markdown, team_id=None, title=None
     Returns a permalink to the new Canvas, or None on failure.
     """
     try:
-        # Use “channel=…” instead of “channel_id=…” for the Canvas API call
         response = client.conversations_canvases_create(
-            channel=channel_id,
+            channel_id=channel_id,
             title=title or "Poll Results",
             document_content={
                 "type": "markdown",

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -86,8 +86,8 @@ class MockSlackClient:
     def chat_postMessage(self, channel=None, text=None):
         self.messages.append({'channel': channel, 'text': text})
 
-    def conversations_canvases_create(self, channel=None, document_content=None, title=None):
-        self.canvases.append({'channel': channel, 'document_content': document_content, 'title': title})
+    def conversations_canvases_create(self, channel_id=None, document_content=None, title=None):
+        self.canvases.append({'channel_id': channel_id, 'document_content': document_content, 'title': title})
         return {'canvas': {'id': '12345'}}
 
 


### PR DESCRIPTION
## Summary
- fix Canvas API call to use `channel_id=`
- update tests for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ec9ff308832f9eb5ee2567479980